### PR TITLE
Use the correct proof_valid API endpoint

### DIFF
--- a/keybase_proofs/tests/views.py
+++ b/keybase_proofs/tests/views.py
@@ -22,7 +22,7 @@ class TestViews(TestCase):
     @patch('requests.get')
     def test_views(self, mock_requests):
         mock_requests.return_value = MagicMock(status_code=200,
-                                               json=lambda: {'valid_proof': True, 'proof_live': False})
+                                               json=lambda: {'proof_valid': True})
 
         # non-existent user gives a 404
         username = 'bob'
@@ -78,7 +78,7 @@ class TestViews(TestCase):
         self.assertEqual(resp.url, kb_redirect_endpoint_tpl.format(
             domain=domain, username=username, **valid_data))
 
-        kb_endpoint = "https://keybase.io/_/api/1.0/sig/check_proof.json"
+        kb_endpoint = "https://keybase.io/_/api/1.0/sig/proof_valid.json"
         mock_requests.assert_called_once_with(kb_endpoint, params={
             'domain': settings.KEYBASE_PROOFS_DOMAIN,
             'kb_username': valid_data['kb_username'],

--- a/keybase_proofs/views.py
+++ b/keybase_proofs/views.py
@@ -42,7 +42,7 @@ def verify_proof(user, sig_hash, kb_username):
     """
 
     domain = get_domain()
-    endpoint = "https://keybase.io/_/api/1.0/sig/check_proof.json"
+    endpoint = "https://keybase.io/_/api/1.0/sig/proof_valid.json"
     try:
         r = requests.get(endpoint, params={
             'domain': domain,
@@ -52,11 +52,11 @@ def verify_proof(user, sig_hash, kb_username):
         })
         if r.status_code != 200:
             print("Invalid response:", r)
-            return False, False
+            return False
         r_json = r.json()
-        return r_json.get('valid_proof', False), r_json.get('proof_live', False)
+        return r_json.get('proof_valid', False)
     except Exception:
-        return False, False
+        return False
 
 
 class KeybaseProofProfileView(ListView):
@@ -142,7 +142,7 @@ class KeybaseProofView(View):
         kb_ua = request.POST.get('kb_ua')
         error = self._validate(sig_hash, kb_username)
         if error is None:
-            valid_proof, _ = verify_proof(request.user, sig_hash, kb_username)
+            valid_proof = verify_proof(request.user, sig_hash, kb_username)
             if not valid_proof:
                 error = "Invalid signature, please retry"
             else:


### PR DESCRIPTION
From [the documentation](https://keybase.io/docs/proof_integration_guide#2-2-proof-creation):

> When validating the new proof, the identity service should call the `sig/proof_valid` endpoint as mentioned.
>
>     $ http GET https://keybase.io/_/api/1.0/sig/proof_valid.json?domain=beeactivists.com&kb_username=joans&username=josavesbees&sig_hash=90b0ef50119e69063d3a96625195a5ea895071debbb50a111ddde2eba9d4ecf40f
>     { "proof_valid" : true }
>
> If a user tries to post a proof and the Keybase API responds that `proof_valid=false`, the Identity Service should reject this proof. When calling `keybase.io/_/api/1.0/sig/proof_valid.json?...` Keybase verifies the signature preventing:
>
> 1. A user from posting an invalid signature
> 2. A valid signature for a different service
> 3. A user from claiming the wrong account on either service
